### PR TITLE
Add split-screen article reader

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders boot text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const bootElement = screen.getByText(/Initializing The Salon/i);
+  expect(bootElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- introduce `activeTopic` state and `close` command
- display reader pane next to terminal for `read` command
- guard terminal sound in tests and update test to check boot text

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68409dd909648324a08fbe00acbe3629