### PR TITLE
Add news side panel with role-based posting

### DIFF
--- a/server/routes/news.js
+++ b/server/routes/news.js
@@ -7,7 +7,7 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   try {
     const result = await pool.query(
-      'SELECT id, title, content, author_display, created_at FROM posts ORDER BY created_at DESC'
+      'SELECT id, title, content, author_display, created_at FROM news ORDER BY created_at DESC'
     );
     const posts = result.rows.map(row => ({
       id: row.id,
@@ -29,8 +29,12 @@ router.post('/', auth, async (req, res) => {
     return res.status(400).json({ error: 'Title and content are required' });
   }
 
+  if (!['creator', 'admin'].includes(req.userRole)) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+
   try {
-    // we still look up username for the display snapshot
+    // look up username for display snapshot
     const { rows } = await pool.query('SELECT username FROM users WHERE id = $1', [req.userId]);
     if (rows.length === 0) {
       return res.status(400).json({ error: 'User not found' });
@@ -38,7 +42,7 @@ router.post('/', auth, async (req, res) => {
     const username = rows[0].username;
 
     const result = await pool.query(
-      `INSERT INTO posts (title, content, user_id, author_display)
+      `INSERT INTO news (title, content, user_id, author_display)
        VALUES ($1, $2, $3, $4)
        RETURNING id, title, content, author_display, created_at`,
       [title, content, req.userId, username]

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,8 @@ const authRoutes = require('./routes/auth');
 app.use('/api/auth', authRoutes);
 const postRoutes = require('./routes/posts');
 app.use('/api/posts', postRoutes);
+const newsRoutes = require('./routes/news');
+app.use('/api/news', newsRoutes);
 const userRoutes = require('./routes/users');
 app.use('/api/users', userRoutes);
 const adminRoutes = require('./routes/admin');

--- a/server/sql/news.sql
+++ b/server/sql/news.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS news (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  user_id INTEGER REFERENCES users(id),
+  author_display TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add dedicated `/api/news` endpoints and SQL table
- allow all users to create forum posts while restricting news posting to creators/admins
- implement terminal "news" panel with pagination and article reader

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689a3364e2688324af876f22afbab35f